### PR TITLE
Fix output path for Azure deployment

### DIFF
--- a/.github/workflows/azure-static-web-apps-red-mud-001ff3e03.yml
+++ b/.github/workflows/azure-static-web-apps-red-mud-001ff3e03.yml
@@ -30,7 +30,7 @@ jobs:
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: "/" # App source code path
           api_location: "" # Api source code path - optional
-          output_location: "" # Built app content directory - optional
+          output_location: "dist" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:


### PR DESCRIPTION
## Summary
- update Azure Static Web Apps workflow to deploy the Vite build output

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870f37c3680832c99b87850285f47dc