### PR TITLE
Add simple e-bike diagnostics workflow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,8 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-const viteLogo = import.meta.env.BASE_URL + 'vite.svg'
 import './App.css'
+import { Diagnostics } from './components/Diagnostics'
 
 function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+  return <Diagnostics />
 }
 
 export default App

--- a/src/components/Diagnostics.tsx
+++ b/src/components/Diagnostics.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+import { listFaults, getSteps } from '../logic/diagnostics'
+import { FaultSelector } from './FaultSelector'
+import { SolutionSteps } from './SolutionSteps'
+
+export function Diagnostics() {
+  const [selected, setSelected] = useState<string | null>(null)
+
+  const faults = listFaults()
+  const steps = selected ? getSteps(selected) : undefined
+
+  return (
+    <div>
+      <h1>E-Bike Diagnostics</h1>
+      {selected ? (
+        <SolutionSteps steps={steps} onBack={() => setSelected(null)} />
+      ) : (
+        <FaultSelector faults={faults} onSelect={id => setSelected(id)} />
+      )}
+    </div>
+  )
+}

--- a/src/components/FaultSelector.tsx
+++ b/src/components/FaultSelector.tsx
@@ -1,0 +1,21 @@
+import type { FaultInfo } from '../logic/diagnostics'
+
+export type FaultSelectorProps = {
+  faults: FaultInfo[]
+  onSelect: (id: string) => void
+}
+
+export function FaultSelector({ faults, onSelect }: FaultSelectorProps) {
+  return (
+    <div>
+      <h2>Select a problem:</h2>
+      <ul>
+        {faults.map(f => (
+          <li key={f.id}>
+            <button onClick={() => onSelect(f.id)}>{f.question}</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/SolutionSteps.tsx
+++ b/src/components/SolutionSteps.tsx
@@ -1,0 +1,20 @@
+export type SolutionStepsProps = {
+  steps: string[] | undefined
+  onBack: () => void
+}
+
+export function SolutionSteps({ steps, onBack }: SolutionStepsProps) {
+  if (!steps) return null
+
+  return (
+    <div>
+      <h2>Recommended steps</h2>
+      <ol>
+        {steps.map(step => (
+          <li key={step}>{step}</li>
+        ))}
+      </ol>
+      <button onClick={onBack}>Back</button>
+    </div>
+  )
+}

--- a/src/logic/diagnostics.ts
+++ b/src/logic/diagnostics.ts
@@ -1,0 +1,43 @@
+export type FaultInfo = {
+  id: string
+  question: string
+  steps: string[]
+}
+
+const faults: FaultInfo[] = [
+  {
+    id: 'battery',
+    question: 'Battery will not charge',
+    steps: [
+      'Verify the charger is properly connected to the outlet and bike',
+      'Inspect battery terminals for corrosion or debris',
+      'Try a different power outlet or charger if available'
+    ]
+  },
+  {
+    id: 'motor',
+    question: 'Motor does not run',
+    steps: [
+      'Ensure the battery is fully charged',
+      'Check that the motor cutoff switch or brake sensors are not engaged',
+      'Inspect wiring for loose or damaged connections'
+    ]
+  },
+  {
+    id: 'display',
+    question: 'Display will not power on',
+    steps: [
+      'Confirm the battery is connected and switched on',
+      'Check display wiring harness for damage',
+      'Reset the system by disconnecting and reconnecting the battery'
+    ]
+  }
+]
+
+export function listFaults(): FaultInfo[] {
+  return faults
+}
+
+export function getSteps(id: string): string[] | undefined {
+  return faults.find(f => f.id === id)?.steps
+}


### PR DESCRIPTION
## Summary
- create diagnostic logic module
- add components to choose faults and show recommended steps
- replace the counter demo with the diagnostic workflow

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870f669673c832ca4aa6d3d39984a79