### PR TITLE
Add React Router for navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 E-Bike Assistant is an AI-powered tool for diagnosing e-bike and scooter issues. Built with **React**, **TypeScript**, and **Vite**, it provides step-by-step repair guidance and performance tips. The app is designed to run entirely in the browser and can be deployed as a static site.
 
+The app uses **React Router** for client-side navigation. The main routes are:
+- `/` - Home
+- `/diagnostics` - Diagnostics tools
+- `/about` - Project information
+
 ## Setup
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,12 @@
     "": {
       "name": "ebike-assistant-app",
       "version": "0.0.0",
+      "license": "MIT",
       "dependencies": {
         "gh-pages": "^6.3.0",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.6.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -1966,6 +1968,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3157,6 +3168,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
+      "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz",
+      "integrity": "sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3254,6 +3303,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "gh-pages": "^6.3.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/App.css
+++ b/src/App.css
@@ -4,6 +4,14 @@
   padding: 2rem;
   text-align: center;
 }
+nav {
+  margin-bottom: 1rem;
+}
+
+nav a {
+  margin-right: 0.5rem;
+}
+
 
 .logo {
   height: 6em;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,22 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-const viteLogo = import.meta.env.BASE_URL + 'vite.svg'
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
+import Home from './pages/Home'
+import Diagnostics from './pages/Diagnostics'
+import About from './pages/About'
 import './App.css'
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
+      <nav>
+        <Link to="/">Home</Link> |{' '}
+        <Link to="/diagnostics">Diagnostics</Link> |{' '}
+        <Link to="/about">About</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/diagnostics" element={<Diagnostics />} />
+        <Route path="/about" element={<About />} />
+      </Routes>
+    </BrowserRouter>
   )
 }
-
-export default App

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,0 +1,11 @@
+export default function About() {
+  return (
+    <div>
+      <h1>About</h1>
+      <p>
+        The E-Bike Assistant helps you diagnose e-bike and scooter issues entirely
+        in the browser.
+      </p>
+    </div>
+  )
+}

--- a/src/pages/Diagnostics.tsx
+++ b/src/pages/Diagnostics.tsx
@@ -1,0 +1,8 @@
+export default function Diagnostics() {
+  return (
+    <div>
+      <h1>Diagnostics</h1>
+      <p>Tools and troubleshooting steps will appear here.</p>
+    </div>
+  )
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react'
+import reactLogo from '../assets/react.svg'
+const viteLogo = import.meta.env.BASE_URL + 'vite.svg'
+import '../App.css'
+
+export default function Home() {
+  const [count, setCount] = useState(0)
+  return (
+    <>
+      <div>
+        <a href="https://vite.dev" target="_blank">
+          <img src={viteLogo} className="logo" alt="Vite logo" />
+        </a>
+        <a href="https://react.dev" target="_blank">
+          <img src={reactLogo} className="logo react" alt="React logo" />
+        </a>
+      </div>
+      <h1>Vite + React</h1>
+      <div className="card">
+        <button onClick={() => setCount((c) => c + 1)}>
+          count is {count}
+        </button>
+        <p>
+          Edit <code>src/pages/Home.tsx</code> and save to test HMR
+        </p>
+      </div>
+      <p className="read-the-docs">
+        Click on the Vite and React logos to learn more
+      </p>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- install `react-router-dom`
- configure routes for Home, Diagnostics, and About pages
- split Home content into its own component
- document the new routes in the README

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6870f67d3ddc832c82c7739325d841f2