### PR TITLE
Add dark mode header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,14 @@
 import './App.css'
 import { Diagnostics } from './components/Diagnostics'
+import Header from './components/Header'
 
 function App() {
-  return <Diagnostics />
+  return (
+    <>
+      <Header />
+      <Diagnostics />
+    </>
+  )
 }
 
 export default App

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -1,0 +1,23 @@
+.header {
+  background-color: #ffffff;
+  color: #213547;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 0.75rem 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.dark .header {
+  background-color: #1a1a1a;
+  color: #ffffff;
+}
+
+.dark-toggle {
+  border: none;
+  background: transparent;
+  padding: 0.4rem;
+  border-radius: 9999px;
+  cursor: pointer;
+  font-size: 1.2rem;
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react'
+import './Header.css'
+
+const Header: React.FC = () => {
+  const [dark, setDark] = useState(() =>
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  )
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', dark)
+  }, [dark])
+
+  return (
+    <header className="header">
+      <h1 className="header-title">E-BikePro</h1>
+      <button
+        onClick={() => setDark(v => !v)}
+        className="dark-toggle"
+        title="Toggle dark mode"
+      >
+        {dark ? '🌙' : '☀️'}
+      </button>
+    </header>
+  )
+}
+
+export default Header

--- a/src/index.css
+++ b/src/index.css
@@ -3,14 +3,19 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #213547;
+  background-color: #ffffff;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+.dark {
+  color-scheme: dark;
+  color: rgba(255, 255, 255, 0.87);
+  background-color: #242424;
 }
 
 a {
@@ -42,7 +47,7 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #f9f9f9;
   cursor: pointer;
   transition: border-color 0.25s;
 }
@@ -54,15 +59,10 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+.dark button {
+  background-color: #1a1a1a;
+}
+
+.dark a:hover {
+  color: #747bff;
 }


### PR DESCRIPTION
## Summary
- style global light and dark themes
- add `Header` component with dark mode toggle
- render header in the app

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870e462ea54832ca125bac3ea647ea8