### PR TITLE
Fix vite config duplication and ensure plugin deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "gh-pages": "^6.3.0",
     "globals": "^16.3.0",
+    "rollup-plugin-visualizer": "^6.0.3",
+    "vite-plugin-pwa": "^1.0.1",
     "jsdom": "^26.1.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.11",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,7 +31,4 @@ export default defineConfig(() => {
     base: '/ebike-assistant-app/',
     plugins,
   }
-export default defineConfig({
-  plugins: [react()],
-  base: '/ebike-assistant-app/',
 })


### PR DESCRIPTION
## Summary
- remove duplicate `export default` from `vite.config.ts`
- add `rollup-plugin-visualizer` and `vite-plugin-pwa` to dev dependencies

## Testing
- `npm install --no-fund --no-progress --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6871dea74740832c9cac6ce8756a6d2e