### PR TITLE
Fix manifest import in vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,18 @@
 import { defineConfig, type PluginOption } from 'vite'
 import react from '@vitejs/plugin-react'
-import { createRequire } from 'node:module'
+import { readFileSync } from 'node:fs'
 import { visualizer } from 'rollup-plugin-visualizer'
 import { VitePWA } from 'vite-plugin-pwa'
 
 export default defineConfig(() => {
-  const require = createRequire(import.meta.url)
+  const manifest = JSON.parse(
+    readFileSync(new URL('./public/manifest.webmanifest', import.meta.url), 'utf-8'),
+  )
   const plugins: PluginOption[] = [
     react(),
     VitePWA({
       srcDir: 'public',
-      manifest: require('./public/manifest.webmanifest'),
+      manifest,
       manifestFilename: 'manifest.webmanifest',
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg,webmanifest}'],


### PR DESCRIPTION
## Summary
- parse the PWA manifest manually

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68720eb48d88832ca76aac067fd2ee2b